### PR TITLE
Expand priority to ten step range between 0..9

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ orphaned due to crashes.
 - **Periodic (CRON) Jobs** — Automatically enqueue jobs on a cron-like schedule.
   Duplicate jobs are never enqueued, no matter how many nodes you're running.
 
-- **Job Priority** — Prioritize jobs within a queue to run ahead of others.
+- **Job Priority** — Prioritize jobs within a queue to run ahead of others with ten levels of
+  granularity.
 
 - **Historic Metrics** — After a job is processed the row isn't deleted.
   Instead, the job is retained in the database to provide metrics. This allows
@@ -336,7 +337,7 @@ Unique jobs can be configured in the worker, or when the job is built:
 |> Oban.insert()
 ```
 
-Job priority can be specified using an integer from 0 to 3, with 0 being the
+Job priority can be specified using an integer from 0 to 9, with 0 being the
 default and highest priority:
 
 ```elixir
@@ -427,24 +428,21 @@ staging will switch to polling in `local` mode.
 
 ## Prioritizing Jobs
 
-Normally, all available jobs within a queue are executed in the order they were
-scheduled. You can override the normal behavior and prioritize or de-prioritize
-a job by assigning a numerical `priority`.
+Normally, all available jobs within a queue are executed in the order they were scheduled. You can
+override the normal behavior and prioritize or de-prioritize a job by assigning a numerical
+`priority`.
 
-* Priorities from 0-3 are allowed, where 0 is the highest priority and 3 is the
-  lowest.
+* Priorities from 0-9 are allowed, where 0 is the highest priority and 9 is the lowest.
 
-* The default priority is 0, unless specified all jobs have an equally high
-  priority.
+* The default priority is 0, unless specified all jobs have an equally high priority.
 
-* All jobs with a higher priority will execute before any jobs with a lower
-  priority. Within a particular priority jobs are executed in their scheduled
-  order.
+* All jobs with a higher priority will execute before any jobs with a lower priority. Within a
+  particular priority jobs are executed in their scheduled order.
 
 #### Caveats & Guidelines
 
-The default priority is defined in the jobs table. The least intrusive way to
-change it for all jobs is to change the column default:
+The default priority is defined in the jobs table. The least intrusive way to change it for all
+jobs is to change the column default:
 
 ```elixir
 alter table("oban_jobs") do

--- a/lib/oban/engines/basic.ex
+++ b/lib/oban/engines/basic.ex
@@ -131,7 +131,6 @@ defmodule Oban.Engines.Basic do
       |> select([:id, :state])
       |> where([j], j.state in ~w(scheduled retryable))
       |> where([j], not is_nil(j.queue))
-      |> where([j], j.priority in [0, 1, 2, 3])
       |> where([j], j.scheduled_at <= ^DateTime.utc_now())
       |> limit(^limit)
 
@@ -156,7 +155,6 @@ defmodule Oban.Engines.Basic do
       |> select([:id, :queue, :state])
       |> where([j], j.state in ~w(completed cancelled discarded))
       |> where([j], not is_nil(j.queue))
-      |> where([j], j.priority in [0, 1, 2, 3])
       |> where([j], j.scheduled_at < ^time)
       |> limit(^limit)
 

--- a/lib/oban/job.ex
+++ b/lib/oban/job.ex
@@ -185,7 +185,8 @@ defmodule Oban.Job do
     * `:max_attempts` — the maximum number of times a job can be retried if there are errors
       during execution
     * `:meta` — a map containing additional information about the job
-    * `:priority` — a numerical indicator from 0 to 3 of how important this job is relative to
+
+    * `:priority` — a numerical indicator from 0 to 9 of how important this job is relative to
       other jobs in the same queue. The lower the number, the higher priority the job.
     * `:queue` — a named queue to push the job into. Jobs may be pushed into any queue, regardless
       of whether jobs are currently being processed for the queue.
@@ -270,7 +271,7 @@ defmodule Oban.Job do
     |> validate_length(:queue, min: 1, max: 128)
     |> validate_length(:worker, min: 1, max: 128)
     |> validate_number(:max_attempts, greater_than: 0)
-    |> validate_number(:priority, greater_than: -1, less_than: 4)
+    |> validate_number(:priority, greater_than: -1, less_than: 10)
     |> validate_replace()
     |> check_constraint(:attempt, name: :attempt_range)
     |> check_constraint(:max_attempts, name: :positive_max_attempts)
@@ -296,15 +297,21 @@ defmodule Oban.Job do
 
   * `:scheduled`—Jobs inserted with `scheduled_at` in the future are `:scheduled`. After the
     `scheduled_at` time has ellapsed the `Oban.Plugins.Stager` will transition them to `:available`
+
   * `:available`—Jobs without a future `scheduled_at` timestamp are inserted as `:available` and may
     execute immediately
+
   * `:executing`—Available jobs may be ran, at which point they are `:executing`
+
   * `:retryable`—Jobs that fail and haven't exceeded their max attempts are transitiond to
     `:retryable` and rescheduled until after a backoff period. Once the backoff has ellapsed the
     `Oban.Plugins.Stager` will transition them back to `:available`
+
   * `:completed`—Jobs that finish executing succesfully are marked `:completed`
+
   * `:discarded`—Jobs that fail and exhaust their max attempts, or return a `:discard` tuple during
     execution, are marked `:discarded`
+
   * `:cancelled`—Jobs that are cancelled intentionally
 
   """

--- a/lib/oban/migrations/postgres/v10.ex
+++ b/lib/oban/migrations/postgres/v10.ex
@@ -10,12 +10,6 @@ defmodule Oban.Migrations.Postgres.V10 do
       modify :priority, :integer, null: false
     end
 
-    # These could happen from an insert_all call with invalid data
-    create constraint(:oban_jobs, :priority_range,
-             check: "priority between 0 and 3",
-             prefix: prefix
-           )
-
     create constraint(:oban_jobs, :positive_max_attempts,
              check: "max_attempts > 0",
              prefix: prefix

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -96,4 +96,6 @@ defmodule Oban.Validation do
        "expected #{inspect(key)} to be a positive integer or :infinity, got: #{inspect(value)}"}
     end
   end
+
+  # Type Validators
 end

--- a/lib/oban/validation.ex
+++ b/lib/oban/validation.ex
@@ -96,6 +96,4 @@ defmodule Oban.Validation do
        "expected #{inspect(key)} to be a positive integer or :infinity, got: #{inspect(value)}"}
     end
   end
-
-  # Type Validators
 end

--- a/lib/oban/worker.ex
+++ b/lib/oban/worker.ex
@@ -441,9 +441,9 @@ defmodule Oban.Worker do
   end
 
   defp validate_opt!({:priority, priority}) do
-    unless is_integer(priority) and priority > -1 and priority < 4 do
+    unless is_integer(priority) and priority > -1 and priority < 10 do
       raise ArgumentError,
-            "expected :priority to be an integer from 0 to 3, got: #{inspect(priority)}"
+            "expected :priority to be an integer from 0 to 9, got: #{inspect(priority)}"
     end
   end
 

--- a/test/oban/job_test.exs
+++ b/test/oban/job_test.exs
@@ -10,6 +10,19 @@ defmodule Oban.JobTest do
       refute changeset.valid?
       assert {"unknown option :workr provided", _} = changeset.errors[:base]
     end
+
+    test "validating priority values" do
+      assert Job.new(%{}, priority: -1).errors[:priority]
+      assert Job.new(%{}, priority: 10).errors[:priority]
+
+      refute Job.new(%{}, priority: 0).errors[:priority]
+      refute Job.new(%{}, priority: 9).errors[:priority]
+    end
+
+    test "validating max_attempt values" do
+      assert Job.new(%{}, max_attempts: 0).errors[:max_attempts]
+      refute Job.new(%{}, max_attempts: 1).errors[:max_attempts]
+    end
   end
 
   describe "scheduling with new/2" do

--- a/test/oban/worker_test.exs
+++ b/test/oban/worker_test.exs
@@ -136,8 +136,26 @@ defmodule Oban.WorkerTest do
 
   test "validating the priority provided to __using__" do
     assert_raise ArgumentError, ~r/expected :priority to be/, fn ->
+      defmodule NegativePriority do
+        use Oban.Worker, priority: -1
+
+        def perform(_), do: :ok
+      end
+    end
+
+    assert_raise ArgumentError, ~r/expected :priority to be/, fn ->
       defmodule InvalidPriority do
-        use Oban.Worker, priority: 11
+        use Oban.Worker, priority: 10
+
+        def perform(_), do: :ok
+      end
+    end
+  end
+
+  test "validating replace options provided to __using__" do
+    assert_raise ArgumentError, ~r/invalid value for :replace/, fn ->
+      defmodule InvalidReplace do
+        use Oban.Worker, replace: [unknown: [:thing]]
 
         def perform(_), do: :ok
       end


### PR DESCRIPTION
This increases the priority range from 4 (0..3) to 10 (0..9) to allow finger grained ordering for more complex use cases. One critical caveat is that users _must drop_ the priority check constraint from the database before they can use priorities greater than 3.